### PR TITLE
feat(nsq): update to version nsq-1.1.0

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -8,12 +8,12 @@ RUN adduser --system \
       nsq \
     && curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > /usr/bin/jq \
     && chmod +x /usr/bin/jq \
-    && curl -sL https://github.com/nsqio/nsq/releases/download/v1.0.0-compat/nsq-1.0.0-compat.linux-amd64.go1.8.tar.gz | tar xz \
-    && mv /nsq-1.0.0-compat.linux-amd64.go1.8/bin/* /bin \
-    && rm -r /nsq-1.0.0-compat.linux-amd64.go1.8 \
+    && curl -sL https://github.com/nsqio/nsq/releases/download/v1.1.0/nsq-1.1.0.linux-amd64.go1.10.3.tar.gz | tar xz \
+    && mv /nsq-1.1.0.linux-amd64.go1.10.3/bin/* /bin \
+    && rm -r /nsq-1.1.0.linux-amd64.go1.10.3 \
     && mkdir /opt/nsq/data
 
 COPY . /
 RUN chown -R nsq:nsq /opt/nsq
 USER nsq
-WORKDIR /opt/nsq/data
+WORKDIR /

--- a/rootfs/opt/nsq/bin/start-nsqd
+++ b/rootfs/opt/nsq/bin/start-nsqd
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -eo pipefail
 
-export MAX_READY_COUNT=${MAX_READY_COUNT:-10000}
-export DATA_PATH=${DATA_PATH:-/opt/nsq/data}
 export CONFIG_PATH=${CONFIG_PATH:-/opt/nsq/conf/nsqd.cfg}
 exec nsqd -config "${CONFIG_PATH}"

--- a/rootfs/opt/nsq/conf/nsqd.cfg
+++ b/rootfs/opt/nsq/conf/nsqd.cfg
@@ -1,9 +1,9 @@
 ## log verbosity level: debug, info, warn, error, or fatal
-log-level = "warn"
+log_level = "warn"
 verbose = false
 
 ## path to store disk-backed messages
-# data_path = "/opt/nsq/data"
+data_path = "/opt/nsq/data"
 
 ## maximum RDY count for a client
 max_rdy_count = 10000


### PR DESCRIPTION
Upgrading the nsq version to 1.1.0 and setting log level to warn to save on the logs. Users can override this setting by editing the config and building their own image for now.

Finishes the work on PR #4 